### PR TITLE
Make the starter easier to work with

### DIFF
--- a/start_point/hikertests.swift
+++ b/start_point/hikertests.swift
@@ -14,9 +14,7 @@ class HikerTests: XCTestCase {
 }
 
 extension HikerTests {
-  static var allTests : [(String, (HikerTests) -> () throws -> Void)] {
-    var name = "testLife_the_universe_and_everything"
-    var fun = testLife_the_universe_and_everything
-    return [ (name, fun), ]
-  }
+    static var allTests = [
+        ("testLife_the_universe_and_everything", testLife_the_universe_and_everything),
+    ]
 }

--- a/start_point/hikertests.swift
+++ b/start_point/hikertests.swift
@@ -8,6 +8,11 @@ class HikerTests: XCTestCase {
     hiker = Hiker()
   }
 
+  override func tearDown() {
+    hiker = nil
+    super.tearDown()
+  }
+
   func testLife_the_universe_and_everything() {
     XCTAssertEqual(hiker.answer(), 42)
   }

--- a/start_point/hikertests.swift
+++ b/start_point/hikertests.swift
@@ -1,21 +1,21 @@
 import XCTest
 
 class HikerTests: XCTestCase {
-  var hiker : Hiker!
+    var hiker: Hiker!
 
-  override func setUp() {
-    super.setUp()
-    hiker = Hiker()
-  }
+    override func setUp() {
+        super.setUp()
+        hiker = Hiker()
+    }
 
-  override func tearDown() {
-    hiker = nil
-    super.tearDown()
-  }
+    override func tearDown() {
+        hiker = nil
+        super.tearDown()
+    }
 
-  func testLife_the_universe_and_everything() {
-    XCTAssertEqual(hiker.answer(), 42)
-  }
+    func testLife_the_universe_and_everything() {
+        XCTAssertEqual(hiker.answer(), 42)
+    }
 }
 
 extension HikerTests {

--- a/start_point/hikertests.swift
+++ b/start_point/hikertests.swift
@@ -1,20 +1,8 @@
 import XCTest
 
 class HikerTests: XCTestCase {
-    var hiker: Hiker!
-
-    override func setUp() {
-        super.setUp()
-        hiker = Hiker()
-    }
-
-    override func tearDown() {
-        hiker = nil
-        super.tearDown()
-    }
-
     func testLife_the_universe_and_everything() {
-        XCTAssertEqual(hiker.answer(), 42)
+        XCTAssertEqual(Hiker().answer(), 42)
     }
 }
 

--- a/start_point/main.swift
+++ b/start_point/main.swift
@@ -1,3 +1,5 @@
 import XCTest
 
-XCTMain([ testCase(HikerTests.allTests) ])
+XCTMain([
+    testCase(HikerTests.allTests),
+])


### PR DESCRIPTION
- Simplify `allTests` (which also removes warnings)
- Avoid `setUp` - not needed for most exercises
- Indent everything to 4 spaces to match cyber-dojo editor
- Reformat `main` to make it easier to add/remove test suites